### PR TITLE
Tweaked composer.json fields for K3 panel display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "schnti/cachebuster",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "type": "kirby-plugin",
   "description": "A plugin for Kirby 3 CMS to add modification timestamps to css and js files",
   "homepage": "https://github.com/schnti/kirby3-cachebuster",

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,17 @@
 {
   "name": "schnti/cachebuster",
-  "description": "Kirby 3 Cachebuster Plugin",
+  "version": "1.0.0",
+  "type": "kirby-plugin",
+  "description": "A plugin for Kirby 3 CMS to add modification timestamps to css and js files",
+  "homepage": "https://github.com/schnti/kirby3-cachebuster",
   "license": "MIT",
   "authors": [
     {
       "name": "Timo Schneider",
       "email": "info@kleiner-als.de",
-      "homepage": "https://kleiner-als.de"
+      "homepage": "https://kleiner-als.de/"
     }
   ],
-  "type": "kirby-plugin",
   "keywords": [
     "kirby3",
     "kirby3-cms",


### PR DESCRIPTION
- Added root `homepage` field to `composer.json` so that the plugin name is linked back to the repository when viewed in the Kirby 3 panel
- Added `version` field to `composer.json` so that the installed version of plugin is displayed in the Kirby 3 panel
- Added trailing slash to `authors:homepage` field for consistency
- Rewrote plugin `description` based on text from read me file